### PR TITLE
Moved nodeunit to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-contrib-jshint": "~0.8.0",
-    "grunt-contrib-nodeunit": "~0.2.2"
-  },
-  "dependencies": {
+    "grunt-contrib-nodeunit": "~0.2.2",
     "nodeunit": "~0.8.2"
   }
 }


### PR DESCRIPTION
nodeunit is not necessary to use this package.
