### PR TITLE
Updating documentation links to TC8, fixing codestyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![Build Status](https://travis-ci.org/pifantastic/teamcity-service-messages.png)](https://travis-ci.org/pifantastic/teamcity-service-messages)
 
-From the [TeamCity documentation](http://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity):
+From the [TeamCity documentation][tcd]:
 
 > If TeamCity doesn't support your testing framework or build runner out of the box, you
 > can still avail yourself of many TeamCity benefits by customizing your build scripts to
-> interact with the TeamCity |server. This makes a wide range of features available to any
+> interact with the TeamCity server. This makes a wide range of features available to any
 > team regardless of their testing frameworks and runners. Some of these features include
 > displaying real-time test results and customized statistics, changing the build status,
 > and publishing artifacts before the build is finished.
@@ -28,8 +28,8 @@ var tsm = require('teamcity-service-messages');
 tsm.testStarted({ name: 'my test' }).testFinished({ name: "my test" });
 
 // You'll more likely use it like this:
-
 tsm.message({ text: 'Finished step 1'});
+
 // Do some stuff.
 tsm.message({ text: 'Finished step 2'});
 ```
@@ -43,7 +43,7 @@ tsm.message({ text: 'Finished step 2'});
 
 #### Methods
 
-[Full Documentation](http://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity)
+[Full Documentation][tcd]
 
 * `blockOpened`/`blockClosed`
 * `message`
@@ -122,3 +122,5 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+[tcd]: http://confluence.jetbrains.com/display/TCD8/Build+Script+Interaction+with+TeamCity

--- a/lib/message.js
+++ b/lib/message.js
@@ -1,4 +1,3 @@
-
 var util = require('util');
 
 /**
@@ -21,7 +20,7 @@ Message.flowId = Math.floor(Math.random() * (1e10 - 1e6 + 1)) + 1e6;
  *
  * @param  {String} key
  * @param  {String} value
- * @return {this}
+ * @return {Message}
  */
 Message.prototype.arg = function (key, value) {
 	this.args[key] = value;
@@ -30,7 +29,7 @@ Message.prototype.arg = function (key, value) {
 
 /**
  * Escape string for TeamCity output.
- * http://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity
+ * @see http://confluence.jetbrains.com/display/TCD8/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ServiceMessages
  *
  * @param  {String} str
  * @return {String}
@@ -57,7 +56,7 @@ Message.prototype.escape = function (str) {
 		else {
 			return '';
 		}
-	} );
+	});
 };
 
 /**
@@ -65,8 +64,8 @@ Message.prototype.escape = function (str) {
  *
  * @return {String}
  */
-Message.prototype.formatArgs = function() {
-	return Object.keys(this.args).map(function(key) {
+Message.prototype.formatArgs = function () {
+	return Object.keys(this.args).map(function (key) {
 		return util.format('%s=\'%s\'', key, this.escape(this.args[key]));
 	}, this).join(' ');
 };
@@ -76,7 +75,7 @@ Message.prototype.formatArgs = function() {
  *
  * @return {String}
  */
-Message.prototype.toString = function() {
+Message.prototype.toString = function () {
 	if (!this.args.timestamp) {
 		this.arg('timestamp', new Date().toISOString());
 	}


### PR DESCRIPTION
- Updated documentation links from TC7 to TC8, eliminated copy-paste.
- Codestyle changes is about spaces between `function` and parenthesis.
- Fixed some JSDoc and removed extra empty lines
