### PR TITLE
Fixed timestamp format: removed 'Z' at the end

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -109,7 +109,8 @@ Message.prototype.toString = function () {
 	}
 
 	if (!this.args.timestamp) {
-		this.arg('timestamp', new Date().toISOString());
+		// TeamCity not fully support ISO 8601 (see TW-36173) so we need to cut off 'Z' at the end.
+		this.arg('timestamp', new Date().toISOString().slice(0, -1));
 	}
 
 	return util.format('##teamcity[%s %s]', this.type, this.formatArgs());

--- a/tests/index.js
+++ b/tests/index.js
@@ -16,11 +16,12 @@ exports.testConstructor = function (test) {
 };
 
 exports.testDefaults = function (test) {
-	test.expect(2);
+	test.expect(3);
 
-	var message = new Message("test");
-	test.ok(~message.toString().indexOf("timestamp='"), "Message should have a timestamp");
-	test.ok(~message.toString().indexOf("flowId='"), "Message should have a flowId");
+	var message = new Message("test").toString();
+	test.ok(~message.indexOf("timestamp='"), "Message should have a timestamp");
+	test.ok(/timestamp='[-T.:\d]+'/.test(message), "Message should not have 'Z' in timestamp");
+	test.ok(~message.indexOf("flowId='"), "Message should have a flowId");
 
 	test.done();
 };


### PR DESCRIPTION
TeamCity not fully support ISO 8601 so we need to cut off 'Z' suffix.

See:
- http://youtrack.jetbrains.com/issue/TW-36173
- http://en.wikipedia.org/wiki/ISO_8601#UTC
