### PR TITLE
Fix escaping of 'undefined' input

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -70,6 +70,10 @@ Message.prototype.arg = function (key, value) {
  * @return {String}
  */
 Message.prototype.escape = function (str) {
+	if (!str) {
+		return '';
+	}
+
 	var replacer = /['\n\r\|\[\]\u0100-\uffff]/g;
 
 	var map = {

--- a/tests/index.js
+++ b/tests/index.js
@@ -53,10 +53,11 @@ exports.testFlowId = function (test) {
 };
 
 exports.testEscape = function (test) {
-	test.expect(9);
+	test.expect(10);
 
 	var escape = Message.prototype.escape;
 
+	test.equal(escape(), "", "Should handle 'undefined' input");
 	test.equal(escape("'"), "|'", "Should escape single quotes");
 	test.equal(escape("|"), "||", "Should escape pipes");
 	test.equal(escape("\n"), "|n", "Should escape newlines");


### PR DESCRIPTION
We have some cases when the input of method `escape` is `undefined`. This case should be handled, shouldn't it?