### PR TITLE
Escape only characters specified in teamcity docs

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -64,7 +64,7 @@ Message.prototype.arg = function (key, value) {
 
 /**
  * Escape string for TeamCity output.
- * @see http://confluence.jetbrains.com/display/TCD8/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ServiceMessages
+ * @see https://confluence.jetbrains.com/display/TCD65/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-servMsgsServiceMessages
  *
  * @param  {String} str
  * @return {String}
@@ -74,28 +74,17 @@ Message.prototype.escape = function (str) {
 		return '';
 	}
 
-	var replacer = /['\n\r\|\[\]\u0100-\uffff]/g;
-
-	var map = {
-		'\'': '|\'',
-		'|': '||',
-		'\n': '|n',
-		'\r': '|r',
-		'[': '|[',
-		']': '|]'
-	};
-
-	return str.toString().replace(replacer, function (character) {
-		if (character in map) {
-			return map[character];
-		}
-		else if (/[^\u0000-\u00ff]/.test(character)) {
-			return '|0x' + padLeft(character.charCodeAt(0).toString(16), '0000');
-		}
-		else {
-			return '';
-		}
-	});
+	return str
+	    .toString()
+	    .replace(/\|/g, '||')
+	    .replace(/\n/g, '|n')
+	    .replace(/\r/g, '|r')
+	    .replace(/\[/g, '|[')
+	    .replace(/\]/g, '|]')
+	    .replace(/\u0085/g, '|x') // next line
+	    .replace(/\u2028/g, '|l') // line separator
+	    .replace(/\u2029/g, '|p') // paragraph separator
+	    .replace(/'/g, '|\'');
 };
 
 /**

--- a/tests/index.js
+++ b/tests/index.js
@@ -53,7 +53,7 @@ exports.testFlowId = function (test) {
 };
 
 exports.testEscape = function (test) {
-	test.expect(10);
+	test.expect(9);
 
 	var escape = Message.prototype.escape;
 
@@ -63,10 +63,9 @@ exports.testEscape = function (test) {
 	test.equal(escape("\n"), "|n", "Should escape newlines");
 	test.equal(escape("\r"), "|r", "Should escape carriage returns");
 	test.equal(escape("[]"), "|[|]", "Should escape brackets");
-	test.equal(escape("✓"), "|0x2713", "Should escape unicode characters");
-	test.equal(escape("\u0100"), "|0x0100", "Should correctly pad unicode characters");
-	test.equal(escape("я"), "|0x044f", "Should escape russian characters");
-	test.equal(escape("'|\n\r[]✓"), "|'|||n|r|[|]|0x2713", "Should escape all special characters");
+	test.equal(escape("\u0085"), "|x", "Should escape next line");
+	test.equal(escape("\u2028"), "|l", "Should escape line separator");
+	test.equal(escape("\u2029"), "|p", "Should escape paragraph separator");
 
 	test.done();
 };
@@ -112,4 +111,3 @@ exports.testSingleAttribute = function (test) {
 
 	test.done();
 };
-


### PR DESCRIPTION
There are some problems with test which have a lot of russian characters - part of the tests will be disappeared from TC log. And all tests was printed normally without escaping of russian characters.
From TC documentation you need to escape only small part of characters - https://confluence.jetbrains.com/display/TCD65/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-servMsgsServiceMessages