### PR TITLE
Export inspectionType and inspection functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ exports.autoFlowId = true;
 	'disableServiceMessages',
 	'enableServiceMessages',
 	'importData',
+	'inspectionType',
+	'inspection',
 	'message',
 	'progressFinish',
 	'progressMessage',


### PR DESCRIPTION
TeamCity supports messages for inspections: `inspectionType` and `inspection`. 
This adds support for these two message types. I needed this enhancement for a
project I'm working on. Thought I'd see if you wanted the change.