### PR TITLE
Fix reporting 0 as empty string

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -70,7 +70,7 @@ Message.prototype.arg = function (key, value) {
  * @return {String}
  */
 Message.prototype.escape = function (str) {
-	if (!str) {
+	if (str == null) {
 		return '';
 	}
 


### PR DESCRIPTION
Sometimes I need to pass 0 as a value