### PR TITLE
Release 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ console.log(message.toString());
 
 ## Changelog
 
+- `0.2.0`
+  - Rewrote the library in TypeScript; type definitions are now generated from the source
+  - Replaced the deprecated `nodeunit` test runner with `mocha` and upgraded TypeScript, resolving all dependency advisories
+  - Publish only the compiled `dist/` output via a `files` allowlist
+  - Removed the dead Travis config in favor of GitHub Actions CI
+  - Requires Node.js >= 14
 - `0.1.12`
   - [#22](https://github.com/pifantastic/teamcity-service-messages/pull/22): Add TypeScript type definitions
 - `0.1.11`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamcity-service-messages",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "description": "Generate TeamCity service messages.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "tsc && mocha tests",
+    "test": "tsc && tsc -p tests/tsconfig.json && mocha tests",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/src/message.ts
+++ b/src/message.ts
@@ -13,20 +13,20 @@ export class Message {
 
 	type: string;
 	single: boolean;
-	args: Args | string | number;
+	args: Record<string, unknown> | string | number;
 
-	constructor(type: string, args?: Args | string | number) {
+	constructor(type: string, args?: unknown) {
 		this.type = type;
 		this.single = false;
 
 		// Message is a 'multiple attribute message'.
 		if (typeof args === 'object' || typeof args === 'undefined') {
-			this.args = args || {};
+			this.args = (args as Record<string, unknown>) || {};
 		}
 		// Message is a 'single attribute message'.
 		else {
 			this.single = true;
-			this.args = args;
+			this.args = args as string | number;
 		}
 
 		if (!this.single) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -90,4 +90,89 @@ describe("teamcity-service-messages", function () {
 			message.arg('foo', 'bar');
 		}, "Adding an arg to a single message should throw an error");
 	});
+
+	it("testAllMethods", function () {
+		// Representative args for every public method. Guards the method list
+		// and each method's emitted message type (every method is now hand
+		// written rather than generated from a list).
+		var cases = {
+			blockOpened: { name: "b", description: "d" },
+			blockClosed: { name: "b" },
+			buildNumber: "1.2.3",
+			buildProblem: { description: "oops" },
+			buildStatisticValue: { key: "k", value: 1 },
+			buildStatus: { text: "t" },
+			compilationStarted: { compiler: "c" },
+			compilationFinished: { compiler: "c" },
+			disableServiceMessages: undefined,
+			enableServiceMessages: undefined,
+			importData: { type: "junit", path: "/p" },
+			inspectionType: { id: "i", name: "n", category: "c", description: "d" },
+			inspection: { typeId: "t", file: "f" },
+			message: { text: "m" },
+			progressStart: "starting",
+			progressMessage: "going",
+			progressFinish: "done",
+			publishArtifacts: "dist/**",
+			setParameter: { name: "p", value: "v" },
+			testFailed: { name: "t" },
+			testFinished: { name: "t" },
+			testIgnored: { name: "t" },
+			testMetadata: { name: "t" },
+			testStarted: { name: "t" },
+			testStdErr: { name: "t", out: "e" },
+			testStdOut: { name: "t", out: "o" },
+			testSuiteStarted: { name: "s" },
+			testSuiteFinished: { name: "s" }
+		};
+
+		var previous = tsm.stdout;
+		tsm.stdout = false;
+		try {
+			Object.keys(cases).forEach(function (name) {
+				assert.equal(typeof tsm[name], "function", name + " should be a method");
+				var arg = cases[name];
+				var output = arg === undefined ? tsm[name]() : tsm[name](arg);
+				assert.equal(
+					output.indexOf("##teamcity[" + name + " "), 0,
+					name + " should emit a '" + name + "' service message, got: " + output
+				);
+			});
+		} finally {
+			tsm.stdout = previous;
+		}
+	});
+
+	it("testStdoutDisabled", function () {
+		var previous = tsm.stdout;
+		tsm.stdout = false;
+		try {
+			var result = tsm.message({ text: "x" });
+			assert.equal(typeof result, "string", "With stdout disabled methods return the message string");
+			assert.ok(~result.indexOf("##teamcity[message "), "Returned value should be the service message");
+		} finally {
+			tsm.stdout = previous;
+		}
+	});
+
+	it("testFalsyValues", function () {
+		// Regression guard for #20 ("Fix reporting 0 as empty string").
+		var zero = new Message("buildStatisticValue", { key: "k", value: 0 }).toString();
+		assert.ok(~zero.indexOf("value='0'"), "Zero should render as '0', not empty, got: " + zero);
+
+		var bool = new Message("test", { flag: false }).toString();
+		assert.ok(~bool.indexOf("flag='false'"), "false should render as 'false', got: " + bool);
+	});
+
+	it("testTimestampOverride", function () {
+		var ts = "2020-01-02T03:04:05.678";
+		var message = new Message("test", { timestamp: ts }).toString();
+		assert.ok(~message.indexOf("timestamp='" + ts + "'"), "Provided timestamp should be used verbatim, got: " + message);
+	});
+
+	it("testEscapingInOutput", function () {
+		// Values (not just the escape() helper) should be escaped in real output.
+		var message = new Message("test", { key: "a'b|c" }).toString();
+		assert.ok(~message.indexOf("key='a|'b||c'"), "Arg values should be escaped in output, got: " + message);
+	});
 });

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["types.ts"]
+}

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,0 +1,39 @@
+/**
+ * Compile-only fixture that locks the public type surface. It is type-checked
+ * (not executed) via `tsc -p tests/tsconfig.json`; the `@ts-expect-error` lines
+ * fail the build if a bad call ever starts compiling.
+ */
+import tsm = require('../dist');
+
+// Chainable, correctly-typed calls.
+tsm.testStarted({ name: 't' }).testFinished({ name: 't', duration: 5 });
+tsm.buildStatus({ status: 'FAILURE', text: 'boom' });
+tsm.buildNumber(42);
+tsm.message({ text: 'hi', status: 'WARNING' });
+tsm.importData({ type: 'junit', path: '/p' });
+
+// Argument interfaces are reachable by qualified name.
+const blockArgs: tsm.BlockOpenedArgs = { name: 'b', description: 'd' };
+tsm.blockOpened(blockArgs);
+
+// The low-level Message class is exported and flexible.
+const out: string = new tsm.Message('testStarted', { name: 'my test' }).toString();
+void out;
+
+// Settings toggles are booleans.
+tsm.stdout = false;
+tsm.autoFlowId = false;
+
+// --- Negative cases: each must NOT type-check ---
+
+// @ts-expect-error - missing required `text`
+tsm.buildStatus({ status: 'SUCCESS' });
+
+// @ts-expect-error - `name` must be a string
+tsm.testStarted({ name: 123 });
+
+// @ts-expect-error - invalid importData `type`
+tsm.importData({ type: 'bogus', path: '/p' });
+
+// @ts-expect-error - unknown status literal
+tsm.buildStatus({ status: 'MAYBE', text: 't' });


### PR DESCRIPTION
Minor bump (0.x convention: minor signals notable/breaking-ish changes). Summarizes work already merged to master:

- Rewrote the library in TypeScript; type defs now generated from source
- Replaced deprecated nodeunit with mocha, upgraded TypeScript — cleared all dependency advisories
- Publish only compiled dist/ via a files allowlist
- GitHub Actions CI replaces dead Travis config
- Requires Node.js >= 14